### PR TITLE
Update to Zig 0.14.0-dev.2435

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 zig-cache/
 .zig-cache/
+zig-out/
+.idea/

--- a/build.zig
+++ b/build.zig
@@ -1,22 +1,12 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    // module exports
-    const module = b.addModule("JNI", .{ .root_source_file = .{ .src_path = .{
-        .owner = b,
-        .sub_path = "src/main/zig/lib.zig",
-    } } });
-    module.addIncludePath(.{ .src_path = .{
-        .owner = b,
-        .sub_path = "src/include/jni",
-    } });
-    module.link_libc = true;
     // build options
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
-    const lib = b.addStaticLibrary(.{
-        .name = "zig-jni",
-        .version = .{ .major = 0, .minor = 0, .patch = 1 },
+
+    // module exports
+    const module = b.addModule("JNI", .{
         .root_source_file = b.path("src/main/zig/lib.zig"),
         .target = target,
         .optimize = optimize,
@@ -27,11 +17,5 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
-    lib.root_module.addImport("cjni", cjni.createModule());
-
-    lib.addIncludePath(.{ .src_path = .{
-        .owner = b,
-        .sub_path = "src/include/jni",
-    } });
-    b.installArtifact(lib);
+    module.addImport("cjni", cjni.createModule());
 }

--- a/build.zig
+++ b/build.zig
@@ -17,10 +17,7 @@ pub fn build(b: *std.Build) void {
     const lib = b.addStaticLibrary(.{
         .name = "zig-jni",
         .version = .{ .major = 0, .minor = 0, .patch = 1 },
-        .root_source_file = .{ .src_path = .{
-            .owner = b,
-            .sub_path = "src/main/zig/lib.zig",
-        } },
+        .root_source_file = b.path("src/main/zig/lib.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -21,7 +21,14 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    lib.linkLibC();
+    const cjni = b.addTranslateC(.{
+        .root_source_file = b.path("src/include/jni/jni.h"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    lib.root_module.addImport("cjni", cjni.createModule());
+
     lib.addIncludePath(.{ .src_path = .{
         .owner = b,
         .sub_path = "src/include/jni",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,7 +7,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.14.0",
 
     // Specifies the set of files and directories that are included in this package.
     // Only files and directories listed here are included in the `hash` that

--- a/src/main/zig/lib.zig
+++ b/src/main/zig/lib.zig
@@ -106,17 +106,18 @@ pub inline fn boolToJboolean(b: bool) jboolean {
 /// Exports all functions with C calling convention from the provided `func_struct` type to be
 /// accessible from Java using the JNI.
 pub fn exportJNI(comptime class_name: []const u8, comptime func_struct: type) void {
-    inline for (@typeInfo(func_struct).Struct.decls) |decl| {
+    inline for (@typeInfo(func_struct).@"struct".decls) |decl| {
         const func = comptime @field(func_struct, decl.name);
         const func_type = @TypeOf(func);
 
         // If it is not a function, skip.
-        if (!std.mem.startsWith(u8, @typeName(@TypeOf(func)), "fn")) {
+        if (@typeInfo(func_type) != .@"fn") {
             continue;
         }
 
+
         // If it is not a function with calling convention .C, skip.
-        if (@typeInfo(func_type).Fn.calling_convention != .C) {
+        if (!@typeInfo(func_type).@"fn".calling_convention.eql(.c)) {
             continue;
         }
 
@@ -127,7 +128,7 @@ pub fn exportJNI(comptime class_name: []const u8, comptime func_struct: type) vo
 
         _ = comptime std.mem.replace(u8, tmp_name, ".", "_", export_name[0..]);
 
-        @export(func, .{
+        @export(&func, .{
             .name = export_name[0..],
             .linkage = .strong,
         });
@@ -148,8 +149,8 @@ inline fn valueLen(comptime ArgsType: type) comptime_int {
     const args_type_info = @typeInfo(ArgsType);
 
     return switch (args_type_info) {
-        .Struct => args_type_info.Struct.fields.len,
-        .Void => 0,
+        .@"struct" => |s| s.fields.len,
+        .@"void" => 0,
         else => 1,
     };
 }
@@ -170,7 +171,7 @@ pub fn toJValues(args: anytype) [valueLen(@TypeOf(args))]jvalue {
     const ArgsType = @TypeOf(args);
     const args_type_info = @typeInfo(ArgsType);
 
-    if (args_type_info != .Struct) {
+    if (args_type_info != .@"struct") {
         return switch (ArgsType) {
             jboolean => [1]jvalue{.{ .z = args }},
             jbyte => [1]jvalue{.{ .b = args }},
@@ -190,7 +191,7 @@ pub fn toJValues(args: anytype) [valueLen(@TypeOf(args))]jvalue {
         };
     }
 
-    const fields = args_type_info.Struct.fields;
+    const fields = args_type_info.@"struct".fields;
     var output: [fields.len]jvalue = undefined;
 
     inline for (fields, 0..) |field, i| {

--- a/src/main/zig/lib.zig
+++ b/src/main/zig/lib.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
-pub const cjni = @cImport({
-    @cInclude("jni.h");
-});
+pub const cjni = @import("cjni");
 
 pub const cEnv = cjni.JNIEnv;
 


### PR DESCRIPTION
- Updated deprecated `@typeInfo` logic
- Fixed buildscript using manual struct building instead of `Build.path()` for `root_source_file`
- Replaced `@cImport` with `addTranslateC` in the buildscript, cImport is being removed in 0.14.0: https://github.com/ziglang/zig/issues/20630
- Removed the static library from the install step, it is not required for using this library in other zig projects. The addModule is enough.